### PR TITLE
Update ankiaddonconfig

### DIFF
--- a/src/addon/ankiaddonconfig/README.md
+++ b/src/addon/ankiaddonconfig/README.md
@@ -128,7 +128,8 @@ conf.clone() # returns a deepcopy of the config dictionary
 
 ## Contributing
 
-Please run mypy and black before creating a pull request. You may need to run `python -m pip install aqt PyQt5-stubs` for mypy checks to work.
+Please run mypy and black before creating a pull request. You may need to run `python -m pip install aqt` for mypy checks to work. You may need to uninstall `PyQt5-stubs` and `PyQt5` packages for mypy checks to work.
+
 ```
 python -m mypy .
 python -m black .


### PR DESCRIPTION
Fixes #41.

#41 seems to have been caused by the following line, combined with a Qt bug:
```py
self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
```

This PR also fixes another issue (which might be another Qt bug as well?) where after opening advanced config editor then closing them, the 'close' button in MacOS window bar becomes disabled.